### PR TITLE
SRL-2: Add react-remove-scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hueyyeng/simple-react-lightbox",
-  "version": "3.7.0-0",
+  "version": "3.7.0",
   "description": "A simple but functional light-box for React.",
   "author": "hueyyeng",
   "license": "MIT",
@@ -108,6 +108,7 @@
     "fast-deep-equal": "^3.1.3",
     "framer-motion": "^6.5.1",
     "lodash": "^4.17.21",
+    "react-remove-scroll": "^2.5.5",
     "react-swipeable": "^7.0.0",
     "react-use": "^17.2.4",
     "react-zoom-pan-pinch": "^2.1.3",

--- a/src/SRL/SRLContext/index.js
+++ b/src/SRL/SRLContext/index.js
@@ -28,6 +28,7 @@ const initialState = {
     settings: {
       autoplaySpeed: 3000,
       boxShadow: 'none',
+      removeScrollBar: true,
       disableKeyboardControls: false,
       disablePanzoom: false,
       disableWheelControls: false,

--- a/src/SRL/SRLLightbox/index.js
+++ b/src/SRL/SRLLightbox/index.js
@@ -4,10 +4,12 @@ import PropTypes from 'prop-types'
 import SRLLightboxGallery from './SRLLightboxGallery'
 import { SRLCtx } from '../SRLContext'
 import { AnimatePresence } from 'framer-motion'
+import { RemoveScroll } from 'react-remove-scroll';
 
 function SRLLightbox() {
   const context = useContext(SRLCtx)
   const { isOpened, options } = context
+  const isRemoveScrollBar = options.settings.removeScrollBar
   const isUsingPreact = options.settings.usingPreact
   const vh = useRef()
 
@@ -29,20 +31,24 @@ function SRLLightbox() {
   if (isUsingPreact) {
     return (
       <Portal selector="SRLLightbox" isOpened={isOpened}>
-        <SRLLightboxGallery
-          {...context}
-        />
+        <RemoveScroll removeScrollBar={isRemoveScrollBar}>
+          <SRLLightboxGallery
+            {...context}
+          />
+        </RemoveScroll>
       </Portal>
     )
   } else {
     return (
       <AnimatePresence>
         {isOpened && (
-          <Portal selector="SRLLightbox" isOpened={isOpened}>
-            <SRLLightboxGallery
-              {...context}
-            />
-          </Portal>
+          <RemoveScroll removeScrollBar={isRemoveScrollBar}>
+            <Portal selector="SRLLightbox" isOpened={isOpened}>
+              <SRLLightboxGallery
+                {...context}
+              />
+            </Portal>
+          </RemoveScroll>
         )}
       </AnimatePresence>
     )

--- a/src/SRL/SRLWrapper/index.js
+++ b/src/SRL/SRLWrapper/index.js
@@ -367,6 +367,7 @@ SRLWrapper.propTypes = {
     settings: PropTypes.shape({
       autoplaySpeed: PropTypes.number,
       boxShadow: PropTypes.string,
+      removeScrollBar: PropTypes.bool,
       disableKeyboardControls: PropTypes.bool,
       disablePanzoom: PropTypes.bool,
       disableWheelControls: PropTypes.bool,
@@ -456,6 +457,7 @@ SRLWrapper.defaultProps = {
     settings: {
       autoplaySpeed: 3000,
       boxShadow: 'none',
+      removeScrollBar: true,
       disableKeyboardControls: false,
       disablePanzoom: false,
       disableWheelControls: false,
@@ -514,9 +516,9 @@ SRLWrapper.defaultProps = {
     }
   },
   defaultCallbacks: {
-    onCountSlides: () => {},
-    onSlideChange: () => {},
-    onLightboxClosed: () => {},
-    onLightboxOpened: () => {}
+    onCountSlides: () => { },
+    onSlideChange: () => { },
+    onLightboxClosed: () => { },
+    onLightboxOpened: () => { }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3893,6 +3893,11 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
@@ -4934,6 +4939,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@
     has "^1.0.3"
     has-symbols "^1.0.3"
 
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
+
 get-own-enumerable-property-symbols@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz#b5fde77f22cbe35f390b4e089922c50bce6ef664"
@@ -5357,6 +5367,13 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -6365,7 +6382,7 @@ lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7733,6 +7750,25 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
+react-remove-scroll-bar@^2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
+  integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
+  dependencies:
+    react-style-singleton "^2.2.1"
+    tslib "^2.0.0"
+
+react-remove-scroll@^2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
+  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
 react-scripts@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-5.0.1.tgz#6285dbd65a8ba6e49ca8d651ce30645a6d980003"
@@ -7787,6 +7823,15 @@ react-scripts@^5.0.1:
     workbox-webpack-plugin "^6.4.1"
   optionalDependencies:
     fsevents "^2.3.2"
+
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^2.0.0"
 
 react-swipeable@^7.0.0:
   version "7.0.0"
@@ -8909,6 +8954,11 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
+tslib@^2.0.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
 tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.1:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -9058,10 +9108,25 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
 use-debounce@^8.0.4:
   version "8.0.4"
   resolved "https://registry.yarnpkg.com/use-debounce/-/use-debounce-8.0.4.tgz#27e93b2f010bd0b8ad06e9fc7de891d9ee5d6b8e"
   integrity sha512-fGqsYQzl8kLHF2QpQSgIwgOgJmnh6j5L6SIzQiHdLfwp3q1egUL3btq5Bg2SJysH6A0ILLgT2IqXZKoNJr0nFw==
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Jira: [SRL-2]

Woops I tried to be smart and remove the previous `body-scroll-lock` dependency as I figure using `overflow:hidden` on HTML tag is _really smart_.

That trick works on desktop browser until I tried on actual mobile devices and woops.

As [body-scroll-lock](https://github.com/willmcpo/body-scroll-lock) last update is August 14, 2021 (as of this pull request), I opted for [react-remove-scroll](https://github.com/theKashey/react-remove-scroll) which is still actively maintained and easier to implement.

## Changes

1. Add `react-remove-scroll` to prevent body from scrolling.
2. Expose `removeScrollBar` props to SRLWrapper settings so developer can opt to show/hide scrollbar.

[SRL-2]: https://hueyyeng.atlassian.net/browse/SRL-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ